### PR TITLE
feat: make asset loading configurable for vad-web

### DIFF
--- a/packages/web/src/asset-path.ts
+++ b/packages/web/src/asset-path.ts
@@ -1,4 +1,10 @@
-const currentScript = window.document.currentScript as HTMLScriptElement | null
+// nextjs@14 bundler may attempt to execute this during SSR and crash
+const isWeb = typeof window !== 'undefined' && typeof window.document !== 'undefined'; 
+const currentScript = 
+  isWeb 
+    ? window.document.currentScript as HTMLScriptElement
+    : null
+
 let basePath = ""
 if (currentScript) {
   basePath = currentScript.src

--- a/packages/web/src/default-model-fetcher.ts
+++ b/packages/web/src/default-model-fetcher.ts
@@ -1,0 +1,6 @@
+import { assetPath } from "./asset-path";
+
+export const defaultModelFetcher = (path: string) => (
+  fetch(assetPath(path))
+    .then(model=>model.arrayBuffer())
+);

--- a/packages/web/src/default-model-fetcher.ts
+++ b/packages/web/src/default-model-fetcher.ts
@@ -1,6 +1,4 @@
-import { assetPath } from "./asset-path";
-
-export const defaultModelFetcher = (path: string) => (
-  fetch(assetPath(path))
+export const defaultModelFetcher = (path: string) => {
+  return fetch(path)
     .then(model=>model.arrayBuffer())
-);
+};

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -6,15 +6,32 @@ import {
   FrameProcessorOptions,
   Message,
   NonRealTimeVADOptions,
+  ModelFetcher,
 } from "./_common"
-import { modelFetcher } from "./model-fetcher"
 import { audioFileToArray } from "./utils"
+import { defaultModelFetcher } from "./default-model-fetcher"
+
+
+export interface NonRealTimeVADOptionsWeb extends NonRealTimeVADOptions {
+  modelURL: string,
+  modelFetcher: (path: string) => Promise<ArrayBuffer>,
+} 
+
+export const defaultNonRealTimeVADOptions = {
+  modelURL: "silero_vad.onnx",
+  modelFetcher: defaultModelFetcher
+}
 
 class NonRealTimeVAD extends PlatformAgnosticNonRealTimeVAD {
   static async new(
-    options: Partial<NonRealTimeVADOptions> = {}
+    options: Partial<NonRealTimeVADOptionsWeb> = {}
   ): Promise<NonRealTimeVAD> {
-    return await this._new(modelFetcher, ort, options)
+    const {modelURL, modelFetcher} = {...defaultNonRealTimeVADOptions, ...options};
+    return await this._new(
+      () => modelFetcher(modelURL), 
+      ort, 
+      options
+    )
   }
 }
 

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -10,6 +10,7 @@ import {
 } from "./_common"
 import { audioFileToArray } from "./utils"
 import { defaultModelFetcher } from "./default-model-fetcher"
+import { assetPath } from "./asset-path"
 
 
 export interface NonRealTimeVADOptionsWeb extends NonRealTimeVADOptions {
@@ -18,7 +19,7 @@ export interface NonRealTimeVADOptionsWeb extends NonRealTimeVADOptions {
 } 
 
 export const defaultNonRealTimeVADOptions = {
-  modelURL: "silero_vad.onnx",
+  modelURL: assetPath("silero_vad.onnx"),
   modelFetcher: defaultModelFetcher
 }
 

--- a/packages/web/src/model-fetcher.ts
+++ b/packages/web/src/model-fetcher.ts
@@ -1,6 +1,0 @@
-import { assetPath } from "./asset-path"
-
-export const modelFetcher = async () => {
-  const modelURL = assetPath("silero_vad.onnx")
-  return await fetch(modelURL).then((r) => r.arrayBuffer())
-}


### PR DESCRIPTION
adresses #42 by making modelfetcher and assetPaths configurable.

Now modelFetcher and assetPaths can be supplied by the user. 
I tried to avoid introducing breaking changes by maintaining the default behaviour.

This should be flexible enough to handle other bundlestrategies where one want's to inline the assets eg.:

```
import worklet from 'file-loader!@ricky0123/vad-web/dist/vad.worklet.bundle.min.js'
MicVad.new({
  workletURL: worklet 
})
```

Furthermore it's worth noting that ONNX web assetsPaths need to be configured too.
However I'm unsure this should be done automatically by this library since the paths are exposed globally and can be modified via:

```
import * as ort from "onnxruntime-web"

ort.env.wasm.wasmPaths = {
  "ort-wasm-simd-threaded.wasm": "/ort-wasm-simd-threaded.wasm",
  "ort-wasm-simd.wasm": "/ort-wasm-simd.wasm",
  "ort-wasm.wasm": "/ort-wasm.wasm",
  "ort-wasm-threaded.wasm": "/ort-wasm-threaded.wasm"
}
```