### PR TITLE
Add destroy() method to clean up audio worklet node

### DIFF
--- a/packages/_common/src/messages.ts
+++ b/packages/_common/src/messages.ts
@@ -3,4 +3,5 @@ export enum Message {
   SpeechStart = "SPEECH_START",
   VADMisfire = "VAD_MISFIRE",
   SpeechEnd = "SPEECH_END",
+  SpeechStop = "SPEECH_STOP"
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -106,7 +106,7 @@ export function useMicVAD(options: Partial<ReactRealTimeVADOptions>) {
     })
     return function cleanUp() {
       if (!loading && !errored) {
-        vad?.pause()
+        vad?.destroy()
         setListening(false)
       }
     }

--- a/packages/web/src/real-time-vad.ts
+++ b/packages/web/src/real-time-vad.ts
@@ -86,8 +86,7 @@ export const defaultRealTimeVADOptions: RealTimeVADOptions = {
 }
 
 export class MicVAD {
-  // @ts-ignore
-  audioContext: AudioContext
+  audioContext: AudioContext | null = null
   // @ts-ignore
   stream: MediaStream
   // @ts-ignore
@@ -135,13 +134,25 @@ export class MicVAD {
     this.audioNodeVAD.start()
     this.listening = true
   }
+
+  destroy = () => {
+    if (this.listening) {
+      this.pause()
+    }
+    this.stream.getTracks().forEach((t) => t.stop())
+    this.audioContext?.close()
+    this.audioContext = null
+    this.audioNodeVAD.entryNode.port.postMessage({
+      message: Message.SpeechStop,
+    })
+  }
 }
 
 export class AudioNodeVAD {
   // @ts-ignore
   frameProcessor: FrameProcessor
   // @ts-ignore
-  entryNode: AudioNode
+  entryNode: AudioWorkletNode
 
   static async new(
     ctx: AudioContext,

--- a/packages/web/src/worklet.ts
+++ b/packages/web/src/worklet.ts
@@ -8,11 +8,19 @@ class Processor extends AudioWorkletProcessor {
   // @ts-ignore
   resampler: Resampler
   _initialized = false
+  _stopProcessing = false
   options: WorkletOptions
 
   constructor(options) {
     super()
     this.options = options.processorOptions as WorkletOptions
+
+    this.port.onmessage = (ev) => {
+      if (ev.data.message === Message.SpeechStop) {
+        this._stopProcessing = true
+      }
+    }
+
     this.init()
   }
   init = async () => {
@@ -42,6 +50,9 @@ class Processor extends AudioWorkletProcessor {
         )
       }
     }
+
+    if (this._stopProcessing) return false
+    
     return true
   }
 }


### PR DESCRIPTION
Based on the fixes in https://github.com/K4UNG/vad.  Fixes #19 and #43.