### PR TITLE
Fix: Stop Audio Stream on Destroy

### DIFF
--- a/packages/web/src/real-time-vad.ts
+++ b/packages/web/src/real-time-vad.ts
@@ -145,6 +145,9 @@ export class MicVAD {
     if (this.listening) {
       this.pause()
     }
+    if (this.options.stream === undefined) {
+      this.stream.getTracks().forEach((track) => track.stop())
+    }
     this.sourceNode.disconnect()
     this.audioNodeVAD.destroy()
     this.audioContext.close()


### PR DESCRIPTION
Right now the browser continues to show that recording is in progress, even after a destroy call. This is happening because if no stream is provided, the library creates its own stream but does not stop it during the destroy phase.

The cleanup issue has been resolved by stopping all tracks on the stream during the destroy process.