### PR TITLE
Fix cleanup race condition in React strict mode

### DIFF
--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -1,3 +1,1 @@
 This is an example of a Nextjs project using @ricky0123/vad-react. It was created using `create-next-app`. The configuration you need to add for your Nextjs project is demonstrated in [./next.config.js](./next.config.js). You can see how the React hook for the VAD is used in [./src/pages/index.tsx](./src/pages/index.tsx).
-
-One caveat - when using the Nextjs development server, the `useMicVAD` hook doesn't behave properly and seems to create two voice activity detectors. I think this may be because [react strict mode](https://nextjs.org/docs/api-reference/next.config.js/react-strict-mode) is enabled, but I have not yet checked whether things work when this is disabled. However, when running with `npm run build && npm run start`, the hook appears to work as intended.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -81,9 +81,14 @@ export function useMicVAD(options: Partial<ReactRealTimeVADOptions>) {
 
   useEffect(() => {
     let myvad: MicVAD | null
+    let canceled = false
     const setup = async (): Promise<void> => {
       try {
         myvad = await MicVAD.new(vadOptions)
+        if (canceled) {
+          myvad.destroy()
+          return
+        }
       } catch (e) {
         setLoading(false)
         if (e instanceof Error) {
@@ -106,6 +111,7 @@ export function useMicVAD(options: Partial<ReactRealTimeVADOptions>) {
     })
     return function cleanUp() {
       myvad?.destroy()
+      canceled = true
       if (!loading && !errored) {
         setListening(false)
       }


### PR DESCRIPTION
## Description of changes

This fixes a race condition where the hook is unloaded before awaiting the Promise to load the VAD completes.

Normally, the cleanup function in the hook will destroy `myvad`. However, if `myvad` hasn't been defined yet (because it is being loaded on `myvad = await MicVAD.new(...)`, the cleanup won't work. This introduces a cancelation variable that will be checked so we know whether or not to ignore the result of the load.

I'm not sure how to add a test for this as it's only relevant when running in React strict mode, so you'd only really see this in a real browser due to the race between the cleanup and the VAD files loading.

<!--
Please describe your changes and link to related issues.
-->

## Checklist

<!--
Please do all of the following that apply to your PR.
If you are submitting an update to the source code of vad-web or vad-react,
all items will likely be relevant. You are welcome to create your PR as a draft
PR without having completed all items.
-->

- [ ] Added a test to verify that changes work as expected (if one doesn't exist already) <!-- can be an automated test or an update to the manual test site -->
- [ ] Ran automated tests successfully <!-- `npm run build && npm run test` -->
- [ ] Viewed manual test site and verified that pages are working <!-- `npm run dev` -->
- [ ] Bumped versions in relevant packages
- [ ] Updated relevant changelogs <!-- see the `/changelogs` directory -->
