### PR TITLE
Updated onFrameProcessed to include processed frame in the callback

### DIFF
--- a/packages/_common/src/frame-processor.ts
+++ b/packages/_common/src/frame-processor.ts
@@ -193,7 +193,7 @@ export class FrameProcessor implements FrameProcessorInterface {
       !this.speaking
     ) {
       this.speaking = true
-      return { probs, msg: Message.SpeechStart }
+      return { probs, msg: Message.SpeechStart, frame }
     }
 
     if (
@@ -213,9 +213,9 @@ export class FrameProcessor implements FrameProcessorInterface {
 
       if (speechFrameCount >= this.options.minSpeechFrames) {
         const audio = concatArrays(audioBuffer.map((item) => item.frame))
-        return { probs, msg: Message.SpeechEnd, audio }
+        return { probs, msg: Message.SpeechEnd, audio, frame }
       } else {
-        return { probs, msg: Message.VADMisfire }
+        return { probs, msg: Message.VADMisfire, frame }
       }
     }
 
@@ -224,6 +224,6 @@ export class FrameProcessor implements FrameProcessorInterface {
         this.audioBuffer.shift()
       }
     }
-    return { probs }
+    return { probs, frame }
   }
 }

--- a/packages/web/src/real-time-vad.ts
+++ b/packages/web/src/real-time-vad.ts
@@ -15,7 +15,7 @@ import { defaultModelFetcher } from "./default-model-fetcher"
 
 interface RealTimeVADCallbacks {
   /** Callback to run after each frame. The size (number of samples) of a frame is given by `frameSamples`. */
-  onFrameProcessed: (probabilities: SpeechProbabilities) => any
+  onFrameProcessed: (probabilities: SpeechProbabilities, frame: Float32Array) => any
 
   /** Callback to run if speech start was detected but `onSpeechEnd` will not be run because the
    * audio segment is smaller than `minSpeechFrames`.
@@ -272,10 +272,11 @@ export class AudioNodeVAD {
       probs: SpeechProbabilities
       msg: Message
       audio: Float32Array
+      frame: Float32Array
     }>
   ) => {
     if (ev.probs !== undefined) {
-      this.options.onFrameProcessed(ev.probs)
+      this.options.onFrameProcessed(ev.probs, ev.frame as Float32Array)
     }
     switch (ev.msg) {
       case Message.SpeechStart:


### PR DESCRIPTION
## Description of changes

Fix to [Issue 68](https://github.com/ricky0123/vad/issues/68).

A lot of use cases need to have audio chunks before user stops talking. To solve this I extended the onFrameProcesses callback to include processed frame, which can be used on the library-user side to concat/play/do whatever.

## Checklist

- [ ] Added a test to verify that changes work as expected (if one doesn't exist already) <!-- can be an automated test or an update to the manual test site -->
- [x] Ran automated tests successfully <!-- `npm run build && npm run test` -->
- [x] Viewed manual test site and verified that pages are working <!-- `npm run dev` -->
- [ ] Bumped versions in relevant packages
- [ ] Updated relevant changelogs <!-- see the `/changelogs` directory -->
