### PR TITLE
Fix positiveSpeechThreshold validation

### DIFF
--- a/packages/_common/src/frame-processor.ts
+++ b/packages/_common/src/frame-processor.ts
@@ -65,16 +65,16 @@ export function validateOptions(options: FrameProcessorOptions) {
   }
   if (
     options.positiveSpeechThreshold < 0 ||
-    options.negativeSpeechThreshold > 1
+    options.positiveSpeechThreshold > 1
   ) {
-    log.error("postiveSpeechThreshold should be a number between 0 and 1")
+    log.error("positiveSpeechThreshold should be a number between 0 and 1")
   }
   if (
     options.negativeSpeechThreshold < 0 ||
     options.negativeSpeechThreshold > options.positiveSpeechThreshold
   ) {
     log.error(
-      "negativeSpeechThreshold should be between 0 and postiveSpeechThreshold"
+      "negativeSpeechThreshold should be between 0 and positiveSpeechThreshold"
     )
   }
   if (options.preSpeechPadFrames < 0) {


### PR DESCRIPTION
## Description of changes

Validation for `positiveSpeechThreshold` was wrong. It was checking for `negativeSpeechThreshold` instead.

## Checklist

<!--
Please do all of the following that apply to your PR.
If you are submitting an update to the source code of vad-web or vad-react,
all items will likely be relevant. You are welcome to create your PR as a draft
PR without having completed all items.
-->

- [ ] Added a test to verify that changes work as expected (if one doesn't exist already) <!-- can be an automated test or an update to the manual test site -->
- [x] Ran automated tests successfully <!-- `npm run build && npm run test` -->
- [x] Viewed manual test site and verified that pages are working <!-- `npm run dev` -->
- [ ] Bumped versions in relevant packages
- [ ] Updated relevant changelogs <!-- see the `/changelogs` directory -->
