### PR TITLE
Stream frames from resampler to non-real-time-vad (take 2)

### DIFF
--- a/examples/node/index.js
+++ b/examples/node/index.js
@@ -2,7 +2,9 @@ const vad = require("@ricky0123/vad-node")
 const wav = require("wav-decoder")
 const fs = require("fs")
 
-const audioSamplePath = `${__dirname}/test.wav`
+const audioSamplePath = process.argv[2] || `${__dirname}/test.wav`
+
+console.log(`Processing ${audioSamplePath}`)
 
 function loadAudio(audioPath) {
   let buffer = fs.readFileSync(audioPath)

--- a/packages/_common/src/non-real-time-vad.ts
+++ b/packages/_common/src/non-real-time-vad.ts
@@ -15,11 +15,13 @@ interface NonRealTimeVADSpeechData {
   end: number
 }
 
-export interface NonRealTimeVADOptions extends FrameProcessorOptions, OrtOptions {}
+export interface NonRealTimeVADOptions
+  extends FrameProcessorOptions,
+    OrtOptions {}
 
 export const defaultNonRealTimeVADOptions: NonRealTimeVADOptions = {
   ...defaultFrameProcessorOptions,
-  ortConfig: undefined
+  ortConfig: undefined,
 }
 
 export class PlatformAgnosticNonRealTimeVAD {

--- a/packages/_common/src/resampler.ts
+++ b/packages/_common/src/resampler.ts
@@ -7,53 +7,78 @@ interface ResamplerOptions {
 }
 
 export class Resampler {
-  inputBuffer: Array<number>
+  inputBuffer: Array<number>;
 
   constructor(public options: ResamplerOptions) {
     if (options.nativeSampleRate < 16000) {
       log.error(
         "nativeSampleRate is too low. Should have 16000 = targetSampleRate <= nativeSampleRate"
-      )
+      );
     }
-    this.inputBuffer = []
+    this.inputBuffer = [];
   }
 
   process = (audioFrame: Float32Array): Float32Array[] => {
-    const outputFrames: Array<Float32Array> = []
+    const outputFrames: Array<Float32Array> = [];
+    this.fillInputBuffer(audioFrame);
 
+    while (this.hasEnoughDataForFrame()) {
+      const outputFrame = this.generateOutputFrame();
+      outputFrames.push(outputFrame);
+    }
+
+    return outputFrames;
+  }
+
+  stream = async function* (audioFrame: Float32Array) {
+    this.fillInputBuffer(audioFrame);
+
+    while (this.hasEnoughDataForFrame()) {
+      const outputFrame = this.generateOutputFrame();
+      yield outputFrame;
+    }
+  }
+
+  private fillInputBuffer(audioFrame: Float32Array) {
     for (const sample of audioFrame) {
-      this.inputBuffer.push(sample)
+      this.inputBuffer.push(sample);
+    }
+  }
+
+  private hasEnoughDataForFrame(): boolean {
+    return (this.inputBuffer.length * this.options.targetSampleRate) /
+      this.options.nativeSampleRate >=
+      this.options.targetFrameSize;
+  }
+
+  private generateOutputFrame(): Float32Array {
+    const outputFrame = new Float32Array(this.options.targetFrameSize);
+    let outputIndex = 0;
+    let inputIndex = 0;
+
+    while (outputIndex < this.options.targetFrameSize) {
+      let sum = 0;
+      let num = 0;
+      while (
+        inputIndex <
+        Math.min(
+          this.inputBuffer.length,
+          ((outputIndex + 1) * this.options.nativeSampleRate) /
+            this.options.targetSampleRate
+        )
+      ) {
+        const value = this.inputBuffer[inputIndex]
+        if (value !== undefined) {
+          sum += value;
+          num++;
+        }
+        inputIndex++;
+      }
+      outputFrame[outputIndex] = sum / num;
+      outputIndex++;
     }
 
-    while (
-      (this.inputBuffer.length * this.options.targetSampleRate) /
-        this.options.nativeSampleRate >
-      this.options.targetFrameSize
-    ) {
-      const outputFrame = new Float32Array(this.options.targetFrameSize)
-      let outputIndex = 0
-      let inputIndex = 0
-      while (outputIndex < this.options.targetFrameSize) {
-        let sum = 0
-        let num = 0
-        while (
-          inputIndex <
-          Math.min(
-            this.inputBuffer.length,
-            ((outputIndex + 1) * this.options.nativeSampleRate) /
-              this.options.targetSampleRate
-          )
-        ) {
-          sum += this.inputBuffer[inputIndex] as number
-          num++
-          inputIndex++
-        }
-        outputFrame[outputIndex] = sum / num
-        outputIndex++
-      }
-      this.inputBuffer = this.inputBuffer.slice(inputIndex)
-      outputFrames.push(outputFrame)
-    }
-    return outputFrames
+    this.inputBuffer = this.inputBuffer.slice(inputIndex);
+    return outputFrame;
   }
 }

--- a/packages/_common/src/resampler.ts
+++ b/packages/_common/src/resampler.ts
@@ -7,58 +7,60 @@ interface ResamplerOptions {
 }
 
 export class Resampler {
-  inputBuffer: Array<number>;
+  inputBuffer: Array<number>
 
   constructor(public options: ResamplerOptions) {
     if (options.nativeSampleRate < 16000) {
       log.error(
         "nativeSampleRate is too low. Should have 16000 = targetSampleRate <= nativeSampleRate"
-      );
+      )
     }
-    this.inputBuffer = [];
+    this.inputBuffer = []
   }
 
   process = (audioFrame: Float32Array): Float32Array[] => {
-    const outputFrames: Array<Float32Array> = [];
-    this.fillInputBuffer(audioFrame);
+    const outputFrames: Array<Float32Array> = []
+    this.fillInputBuffer(audioFrame)
 
     while (this.hasEnoughDataForFrame()) {
-      const outputFrame = this.generateOutputFrame();
-      outputFrames.push(outputFrame);
+      const outputFrame = this.generateOutputFrame()
+      outputFrames.push(outputFrame)
     }
 
-    return outputFrames;
+    return outputFrames
   }
 
   stream = async function* (audioFrame: Float32Array) {
-    this.fillInputBuffer(audioFrame);
+    this.fillInputBuffer(audioFrame)
 
     while (this.hasEnoughDataForFrame()) {
-      const outputFrame = this.generateOutputFrame();
-      yield outputFrame;
+      const outputFrame = this.generateOutputFrame()
+      yield outputFrame
     }
   }
 
   private fillInputBuffer(audioFrame: Float32Array) {
     for (const sample of audioFrame) {
-      this.inputBuffer.push(sample);
+      this.inputBuffer.push(sample)
     }
   }
 
   private hasEnoughDataForFrame(): boolean {
-    return (this.inputBuffer.length * this.options.targetSampleRate) /
-      this.options.nativeSampleRate >=
-      this.options.targetFrameSize;
+    return (
+      (this.inputBuffer.length * this.options.targetSampleRate) /
+        this.options.nativeSampleRate >=
+      this.options.targetFrameSize
+    )
   }
 
   private generateOutputFrame(): Float32Array {
-    const outputFrame = new Float32Array(this.options.targetFrameSize);
-    let outputIndex = 0;
-    let inputIndex = 0;
+    const outputFrame = new Float32Array(this.options.targetFrameSize)
+    let outputIndex = 0
+    let inputIndex = 0
 
     while (outputIndex < this.options.targetFrameSize) {
-      let sum = 0;
-      let num = 0;
+      let sum = 0
+      let num = 0
       while (
         inputIndex <
         Math.min(
@@ -69,16 +71,16 @@ export class Resampler {
       ) {
         const value = this.inputBuffer[inputIndex]
         if (value !== undefined) {
-          sum += value;
-          num++;
+          sum += value
+          num++
         }
-        inputIndex++;
+        inputIndex++
       }
-      outputFrame[outputIndex] = sum / num;
-      outputIndex++;
+      outputFrame[outputIndex] = sum / num
+      outputIndex++
     }
 
-    this.inputBuffer = this.inputBuffer.slice(inputIndex);
-    return outputFrame;
+    this.inputBuffer = this.inputBuffer.slice(inputIndex)
+    return outputFrame
   }
 }

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -6,6 +6,7 @@ import {
   FrameProcessorOptions,
   Message,
   NonRealTimeVADOptions,
+  Resampler,
 } from "./_common"
 import * as fs from "fs/promises"
 
@@ -24,5 +25,5 @@ class NonRealTimeVAD extends PlatformAgnosticNonRealTimeVAD {
   }
 }
 
-export { utils, FrameProcessor, Message, NonRealTimeVAD }
+export { utils, Resampler, FrameProcessor, Message, NonRealTimeVAD }
 export type { FrameProcessorOptions, NonRealTimeVADOptions }

--- a/packages/node/test/resampler.spec.js
+++ b/packages/node/test/resampler.spec.js
@@ -1,0 +1,95 @@
+const vad = require("@ricky0123/vad-node")
+const { assert } = require("chai")
+const { audioSamplePath } = require("./utils")
+const fs = require("fs")
+const wav = require("wav-decoder")
+
+function loadAudio(audioPath) {
+  let buffer = fs.readFileSync(audioPath)
+  let result = wav.decode.sync(buffer)
+  let audioData = new Float32Array(result.channelData[0].length)
+  for (let i = 0; i < audioData.length; i++) {
+    audioData[i] = result.channelData[0][i] // Assuming mono channel for simplicity
+  }
+  return [audioData, result.sampleRate]
+}
+
+describe("Resampler", function () {
+  const testCases = [
+    { targetSampleRate: 8000, targetFrameSize: 160 },
+    { targetSampleRate: 16000, targetFrameSize: 320 },
+    { targetSampleRate: 22050, targetFrameSize: 441 },
+    { targetSampleRate: 44100, targetFrameSize: 882 }
+  ];
+
+  describe("process", function() {
+    const testCases = [
+      { targetSampleRate: 8000, targetFrameSize: 160 },
+      { targetSampleRate: 16000, targetFrameSize: 320 },
+      { targetSampleRate: 22050, targetFrameSize: 441 },
+      { targetSampleRate: 44100, targetFrameSize: 882 }
+    ];
+
+    testCases.forEach(({ targetSampleRate, targetFrameSize }) => {
+      it(`should correctly resample audio to ${targetSampleRate} Hz with frame size ${targetFrameSize}`, async function () {
+        const [audioData, nativeSampleRate] = loadAudio(audioSamplePath);
+
+        const resampler = new vad.Resampler({
+          nativeSampleRate: nativeSampleRate,
+          targetSampleRate: targetSampleRate,
+          targetFrameSize: targetFrameSize
+        });
+
+        const outputFrames = resampler.process(audioData);
+
+        // Calculate expected number of frames, discarding partial frame at the end
+        const duration = audioData.length / nativeSampleRate;
+        const expectedNumberOfFrames = Math.floor(duration * targetSampleRate / targetFrameSize);
+
+        assert.equal(outputFrames.length, expectedNumberOfFrames, "Number of output frames does not match expected");
+
+        // Check if the frame size is correct
+        outputFrames.forEach(frame => {
+          assert.equal(frame.length, targetFrameSize, "Output frame size is incorrect");
+        });
+      });
+    });
+  });
+
+  describe("stream", function () {
+    const testCases = [
+      { targetSampleRate: 8000, targetFrameSize: 160 },
+      { targetSampleRate: 16000, targetFrameSize: 320 },
+      { targetSampleRate: 22050, targetFrameSize: 441 },
+      { targetSampleRate: 44100, targetFrameSize: 882 }
+    ];
+
+    testCases.forEach(({ targetSampleRate, targetFrameSize }) => {
+      it(`should stream resampled audio frames correctly at ${targetSampleRate} Hz with frame size ${targetFrameSize}`, async function () {
+        const [audioData, nativeSampleRate] = loadAudio(audioSamplePath);
+
+        const resampler = new vad.Resampler({
+          nativeSampleRate: nativeSampleRate,
+          targetSampleRate: targetSampleRate,
+          targetFrameSize: targetFrameSize
+        });
+
+        const frameStream = resampler.stream(audioData);
+        let frameCount = 0;
+        let allFramesCorrectSize = true;
+
+        for await (const frame of frameStream) {
+          frameCount++;
+          if (frame.length !== targetFrameSize) {
+            allFramesCorrectSize = false;
+            break;
+          }
+        }
+
+        const expectedNumberOfFrames = Math.floor(audioData.length / nativeSampleRate * targetSampleRate / targetFrameSize);
+        assert.equal(frameCount, expectedNumberOfFrames, "Number of streamed frames does not match expected");
+        assert.isTrue(allFramesCorrectSize, "Not all frames are of the correct size");
+      });
+    });
+  });
+});

--- a/packages/node/test/resampler.spec.js
+++ b/packages/node/test/resampler.spec.js
@@ -19,77 +19,97 @@ describe("Resampler", function () {
     { targetSampleRate: 8000, targetFrameSize: 160 },
     { targetSampleRate: 16000, targetFrameSize: 320 },
     { targetSampleRate: 22050, targetFrameSize: 441 },
-    { targetSampleRate: 44100, targetFrameSize: 882 }
-  ];
+    { targetSampleRate: 44100, targetFrameSize: 882 },
+  ]
 
-  describe("process", function() {
+  describe("process", function () {
     const testCases = [
       { targetSampleRate: 8000, targetFrameSize: 160 },
       { targetSampleRate: 16000, targetFrameSize: 320 },
       { targetSampleRate: 22050, targetFrameSize: 441 },
-      { targetSampleRate: 44100, targetFrameSize: 882 }
-    ];
+      { targetSampleRate: 44100, targetFrameSize: 882 },
+    ]
 
     testCases.forEach(({ targetSampleRate, targetFrameSize }) => {
       it(`should correctly resample audio to ${targetSampleRate} Hz with frame size ${targetFrameSize}`, async function () {
-        const [audioData, nativeSampleRate] = loadAudio(audioSamplePath);
+        const [audioData, nativeSampleRate] = loadAudio(audioSamplePath)
 
         const resampler = new vad.Resampler({
           nativeSampleRate: nativeSampleRate,
           targetSampleRate: targetSampleRate,
-          targetFrameSize: targetFrameSize
-        });
+          targetFrameSize: targetFrameSize,
+        })
 
-        const outputFrames = resampler.process(audioData);
+        const outputFrames = resampler.process(audioData)
 
         // Calculate expected number of frames, discarding partial frame at the end
-        const duration = audioData.length / nativeSampleRate;
-        const expectedNumberOfFrames = Math.floor(duration * targetSampleRate / targetFrameSize);
+        const duration = audioData.length / nativeSampleRate
+        const expectedNumberOfFrames = Math.floor(
+          (duration * targetSampleRate) / targetFrameSize
+        )
 
-        assert.equal(outputFrames.length, expectedNumberOfFrames, "Number of output frames does not match expected");
+        assert.equal(
+          outputFrames.length,
+          expectedNumberOfFrames,
+          "Number of output frames does not match expected"
+        )
 
         // Check if the frame size is correct
-        outputFrames.forEach(frame => {
-          assert.equal(frame.length, targetFrameSize, "Output frame size is incorrect");
-        });
-      });
-    });
-  });
+        outputFrames.forEach((frame) => {
+          assert.equal(
+            frame.length,
+            targetFrameSize,
+            "Output frame size is incorrect"
+          )
+        })
+      })
+    })
+  })
 
   describe("stream", function () {
     const testCases = [
       { targetSampleRate: 8000, targetFrameSize: 160 },
       { targetSampleRate: 16000, targetFrameSize: 320 },
       { targetSampleRate: 22050, targetFrameSize: 441 },
-      { targetSampleRate: 44100, targetFrameSize: 882 }
-    ];
+      { targetSampleRate: 44100, targetFrameSize: 882 },
+    ]
 
     testCases.forEach(({ targetSampleRate, targetFrameSize }) => {
       it(`should stream resampled audio frames correctly at ${targetSampleRate} Hz with frame size ${targetFrameSize}`, async function () {
-        const [audioData, nativeSampleRate] = loadAudio(audioSamplePath);
+        const [audioData, nativeSampleRate] = loadAudio(audioSamplePath)
 
         const resampler = new vad.Resampler({
           nativeSampleRate: nativeSampleRate,
           targetSampleRate: targetSampleRate,
-          targetFrameSize: targetFrameSize
-        });
+          targetFrameSize: targetFrameSize,
+        })
 
-        const frameStream = resampler.stream(audioData);
-        let frameCount = 0;
-        let allFramesCorrectSize = true;
+        const frameStream = resampler.stream(audioData)
+        let frameCount = 0
+        let allFramesCorrectSize = true
 
         for await (const frame of frameStream) {
-          frameCount++;
+          frameCount++
           if (frame.length !== targetFrameSize) {
-            allFramesCorrectSize = false;
-            break;
+            allFramesCorrectSize = false
+            break
           }
         }
 
-        const expectedNumberOfFrames = Math.floor(audioData.length / nativeSampleRate * targetSampleRate / targetFrameSize);
-        assert.equal(frameCount, expectedNumberOfFrames, "Number of streamed frames does not match expected");
-        assert.isTrue(allFramesCorrectSize, "Not all frames are of the correct size");
-      });
-    });
-  });
-});
+        const expectedNumberOfFrames = Math.floor(
+          ((audioData.length / nativeSampleRate) * targetSampleRate) /
+            targetFrameSize
+        )
+        assert.equal(
+          frameCount,
+          expectedNumberOfFrames,
+          "Number of streamed frames does not match expected"
+        )
+        assert.isTrue(
+          allFramesCorrectSize,
+          "Not all frames are of the correct size"
+        )
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Description of changes

Currently long audio files block on resampling before they can be processed. This introduces a Resampler#stream that allows for streaming resampled frames into PlatformAgnosticNonRealTimeVAD. 

Fixes https://github.com/ricky0123/vad/issues/94.

## Checklist

<!--
Please do all of the following that apply to your PR.
If you are submitting an update to the source code of vad-web or vad-react,
all items will likely be relevant. You are welcome to create your PR as a draft
PR without having completed all items.
-->

- [x] Added a test to verify that changes work as expected (if one doesn't exist already) <!-- can be an automated test or an update to the manual test site -->
- [x] Ran automated tests successfully <!-- `npm run build && npm run test` -->
- [x] Viewed manual test site and verified that pages are working <!-- `npm run dev` -->
- [ ] Bumped versions in relevant packages
- [ ] Updated relevant changelogs <!-- see the `/changelogs` directory -->
