### PR TITLE
Fix blocking issue in Resampler.stream

### DIFF
--- a/changelogs/node-changelog.md
+++ b/changelogs/node-changelog.md
@@ -1,5 +1,9 @@
 # @ricky0123/vad-node Changelog
 
+## 0.0.4
+
+* fix streaming resampler for large files
+
 ## 0.0.3
 
 * modify resampler to handle larger audio files

--- a/packages/_common/src/resampler.ts
+++ b/packages/_common/src/resampler.ts
@@ -20,28 +20,27 @@ export class Resampler {
 
   process = (audioFrame: Float32Array): Float32Array[] => {
     const outputFrames: Array<Float32Array> = []
-    this.fillInputBuffer(audioFrame)
 
-    while (this.hasEnoughDataForFrame()) {
-      const outputFrame = this.generateOutputFrame()
-      outputFrames.push(outputFrame)
+    for (const sample of audioFrame) {
+      this.inputBuffer.push(sample)
+
+      while (this.hasEnoughDataForFrame()) {
+        const outputFrame = this.generateOutputFrame()
+        outputFrames.push(outputFrame)
+      }
     }
 
     return outputFrames
   }
 
-  stream = async function* (audioFrame: Float32Array) {
-    this.fillInputBuffer(audioFrame)
-
-    while (this.hasEnoughDataForFrame()) {
-      const outputFrame = this.generateOutputFrame()
-      yield outputFrame
-    }
-  }
-
-  private fillInputBuffer(audioFrame: Float32Array) {
-    for (const sample of audioFrame) {
+  stream = async function* (audioInput: Float32Array) {
+    for (const sample of audioInput) {
       this.inputBuffer.push(sample)
+
+      while (this.hasEnoughDataForFrame()) {
+        const outputFrame = this.generateOutputFrame()
+        yield outputFrame
+      }
     }
   }
 

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -12,7 +12,7 @@
     "offline-speech-recognition"
   ],
   "homepage": "https://github.com/ricky0123/vad",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "ISC",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/node/test/resampler.spec.js
+++ b/packages/node/test/resampler.spec.js
@@ -3,6 +3,7 @@ const { assert } = require("chai")
 const { audioSamplePath } = require("./utils")
 const fs = require("fs")
 const wav = require("wav-decoder")
+const crypto = require('crypto');
 
 function loadAudio(audioPath) {
   let buffer = fs.readFileSync(audioPath)
@@ -14,23 +15,40 @@ function loadAudio(audioPath) {
   return [audioData, result.sampleRate]
 }
 
+function calculateChecksum(frames) {
+  const hash = crypto.createHash('md5');
+  for (const frame of frames) {
+    hash.update(frame);
+  }
+  return hash.digest('hex');
+}
+
 describe("Resampler", function () {
   const testCases = [
-    { targetSampleRate: 8000, targetFrameSize: 160 },
-    { targetSampleRate: 16000, targetFrameSize: 320 },
-    { targetSampleRate: 22050, targetFrameSize: 441 },
-    { targetSampleRate: 44100, targetFrameSize: 882 },
-  ]
+    { targetSampleRate: 8000, targetFrameSize: 160, expectedNumberOfFrames: 256, expectedChecksum: '94932620f6779362614ecb0fd488a439'},
+    { targetSampleRate: 16000, targetFrameSize: 320, expectedNumberOfFrames: 256, expectedChecksum: 'cc6cfee05d7f0117d0d1b03b561380fa'},
+    { targetSampleRate: 22050, targetFrameSize: 441, expectedNumberOfFrames: 256, expectedChecksum: '074cc9ffaf685298f1d94277f2473387'},
+    { targetSampleRate: 44100, targetFrameSize: 882, expectedNumberOfFrames: 256, expectedChecksum: 'e94ed059238fbc0331747e1642290a33'},
+  ];
+
+  function assertFramesAreResampled(outputFrames, expectedNumberOfFrames, expectedFrameSize) {
+    assert.equal(
+      outputFrames.length,
+      expectedNumberOfFrames,
+      "Number of output frames does not match expected"
+    )
+
+    outputFrames.forEach(frame => {
+      assert.equal(
+        frame.length,
+        expectedFrameSize,
+        `Each frame should be exactly ${expectedFrameSize} samples long`
+      );
+    });
+  }
 
   describe("process", function () {
-    const testCases = [
-      { targetSampleRate: 8000, targetFrameSize: 160 },
-      { targetSampleRate: 16000, targetFrameSize: 320 },
-      { targetSampleRate: 22050, targetFrameSize: 441 },
-      { targetSampleRate: 44100, targetFrameSize: 882 },
-    ]
-
-    testCases.forEach(({ targetSampleRate, targetFrameSize }) => {
+    testCases.forEach(({ targetSampleRate, targetFrameSize, expectedNumberOfFrames, expectedChecksum }) => {
       it(`should correctly resample audio to ${targetSampleRate} Hz with frame size ${targetFrameSize}`, async function () {
         const [audioData, nativeSampleRate] = loadAudio(audioSamplePath)
 
@@ -40,41 +58,17 @@ describe("Resampler", function () {
           targetFrameSize: targetFrameSize,
         })
 
-        const outputFrames = resampler.process(audioData)
+        const resampledAudio = resampler.process(audioData)
+        assertFramesAreResampled(resampledAudio, expectedNumberOfFrames, targetFrameSize)
 
-        // Calculate expected number of frames, discarding partial frame at the end
-        const duration = audioData.length / nativeSampleRate
-        const expectedNumberOfFrames = Math.floor(
-          (duration * targetSampleRate) / targetFrameSize
-        )
-
-        assert.equal(
-          outputFrames.length,
-          expectedNumberOfFrames,
-          "Number of output frames does not match expected"
-        )
-
-        // Check if the frame size is correct
-        outputFrames.forEach((frame) => {
-          assert.equal(
-            frame.length,
-            targetFrameSize,
-            "Output frame size is incorrect"
-          )
-        })
+        const checksum = calculateChecksum(resampledAudio);
+        assert.equal(checksum, expectedChecksum, 'Resampled audio checksum does not match expected');
       })
     })
   })
 
   describe("stream", function () {
-    const testCases = [
-      { targetSampleRate: 8000, targetFrameSize: 160 },
-      { targetSampleRate: 16000, targetFrameSize: 320 },
-      { targetSampleRate: 22050, targetFrameSize: 441 },
-      { targetSampleRate: 44100, targetFrameSize: 882 },
-    ]
-
-    testCases.forEach(({ targetSampleRate, targetFrameSize }) => {
+    testCases.forEach(({ targetSampleRate, targetFrameSize, expectedNumberOfFrames, expectedChecksum }) => {
       it(`should stream resampled audio frames correctly at ${targetSampleRate} Hz with frame size ${targetFrameSize}`, async function () {
         const [audioData, nativeSampleRate] = loadAudio(audioSamplePath)
 
@@ -87,28 +81,21 @@ describe("Resampler", function () {
         const frameStream = resampler.stream(audioData)
         let frameCount = 0
         let allFramesCorrectSize = true
+        let resampledAudio = []
 
         for await (const frame of frameStream) {
           frameCount++
+          resampledAudio.push(frame)
           if (frame.length !== targetFrameSize) {
             allFramesCorrectSize = false
             break
           }
         }
 
-        const expectedNumberOfFrames = Math.floor(
-          ((audioData.length / nativeSampleRate) * targetSampleRate) /
-            targetFrameSize
-        )
-        assert.equal(
-          frameCount,
-          expectedNumberOfFrames,
-          "Number of streamed frames does not match expected"
-        )
-        assert.isTrue(
-          allFramesCorrectSize,
-          "Not all frames are of the correct size"
-        )
+        assertFramesAreResampled(resampledAudio, expectedNumberOfFrames, targetFrameSize)
+
+        const checksum = calculateChecksum(resampledAudio);
+        assert.equal(checksum, expectedChecksum, 'Resampled audio checksum does not match expected');
       })
     })
   })


### PR DESCRIPTION
## Description of changes

Follow-on to #108. 

In the process of trying to keep Resampler.process intact (as it's used by the web package), I missed a spot where the implementation for Resampler.stream blocked on building an input buffer which doesn't show up in the tests, but it does in manual testing with very long files. 

This fixes the issue. 

## Checklist

<!--
Please do all of the following that apply to your PR.
If you are submitting an update to the source code of vad-web or vad-react,
all items will likely be relevant. You are welcome to create your PR as a draft
PR without having completed all items.
-->

- [x] Added a test to verify that changes work as expected (if one doesn't exist already) <!-- can be an automated test or an update to the manual test site -->
- [x] Ran automated tests successfully <!-- `npm run build && npm run test` -->
- [x] Viewed manual test site and verified that pages are working <!-- `npm run dev` -->
- [x] Bumped versions in relevant packages
- [x] Updated relevant changelogs <!-- see the `/changelogs` directory -->
- [x] Ran `npm run format`
