### PR TITLE
make arrayBufferToBase64 faster

### DIFF
--- a/packages/_common/src/utils.ts
+++ b/packages/_common/src/utils.ts
@@ -7,13 +7,13 @@ export function minFramesForTargetMS(
 }
 
 export function arrayBufferToBase64(buffer: ArrayBuffer) {
-  var binary = ""
   var bytes = new Uint8Array(buffer)
   var len = bytes.byteLength
+  var binary = new Array(len)
   for (var i = 0; i < len; i++) {
-    binary += String.fromCharCode(bytes[i] as number)
+    binary[i] = String.fromCharCode(bytes[i])
   }
-  return btoa(binary)
+  return btoa(binary.join(''))
 }
 
 /*


### PR DESCRIPTION
Makes arrayBufferToBase64 about 2-4x faster. It is faster because all the memory is allocated at the beginning of the for loop

Short audio may only take a few milliseconds, but long audio can take upward of 100ms with the old code. This new function can make a noticeable difference in speed