### PR TITLE
Fix typos in frame-processor.ts

### DIFF
--- a/packages/_common/src/frame-processor.ts
+++ b/packages/_common/src/frame-processor.ts
@@ -65,7 +65,7 @@ export function validateOptions(options: FrameProcessorOptions) {
   }
   if (
     options.positiveSpeechThreshold < 0 ||
-    options.negativeSpeechThreshold > 1
+    options.positiveSpeechThreshold > 1
   ) {
     log.error("postiveSpeechThreshold should be a number between 0 and 1")
   }
@@ -81,7 +81,7 @@ export function validateOptions(options: FrameProcessorOptions) {
     log.error("preSpeechPadFrames should be positive")
   }
   if (options.redemptionFrames < 0) {
-    log.error("preSpeechPadFrames should be positive")
+    log.error("redemptionFrames should be positive")
   }
 }
 

--- a/packages/_common/src/frame-processor.ts
+++ b/packages/_common/src/frame-processor.ts
@@ -67,7 +67,7 @@ export function validateOptions(options: FrameProcessorOptions) {
     options.positiveSpeechThreshold < 0 ||
     options.positiveSpeechThreshold > 1
   ) {
-    log.error("postiveSpeechThreshold should be a number between 0 and 1")
+    log.error("positiveSpeechThreshold should be a number between 0 and 1")
   }
   if (
     options.negativeSpeechThreshold < 0 ||


### PR DESCRIPTION
Fixed some typos in frame processor arguments validation.

This is a very tiny change. 