### PR TITLE
fix minor typo in real-time-vad.ts

### DIFF
--- a/packages/web/src/real-time-vad.ts
+++ b/packages/web/src/real-time-vad.ts
@@ -200,7 +200,7 @@ export class AudioNodeVAD {
       console.error(
         `Encountered an error while loading model file. Please make sure silero_vad.onnx, included with @ricky0123/vad-web, is available at the specified path:
       ${fullOptions.modelURL}
-      If need be, you can customize the model file location using the \`modelsURL\` option.`
+      If need be, you can customize the model file location using the \`modelURL\` option.`
       )
       throw e
     }


### PR DESCRIPTION
## Description of changes

Minor typo fix in the error message for `modelURL`.