### PR TITLE
fix unnecessary render causing by userSpeaking check

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,7 +4,7 @@ import {
   MicVAD,
   getDefaultRealTimeVADOptions,
 } from "@ricky0123/vad-web"
-import React, { useEffect, useReducer, useState } from "react"
+import React, { useEffect, useState } from "react"
 
 export { utils } from "@ricky0123/vad-web"
 
@@ -65,11 +65,7 @@ function useEventCallback<T extends (...args: any[]) => any>(fn: T): T {
 
 export function useMicVAD(options: Partial<ReactRealTimeVADOptions>) {
   const [reactOptions, vadOptions] = useOptions(options)
-  const [userSpeaking, updateUserSpeaking] = useReducer(
-    (state: boolean, isSpeechProbability: number) =>
-      isSpeechProbability > reactOptions.userSpeakingThreshold,
-    false
-  )
+  const [userSpeaking, updateUserSpeaking] = useState(false)
   const [loading, setLoading] = useState(true)
   const [errored, setErrored] = useState<false | string>(false)
   const [listening, setListening] = useState(false)
@@ -77,7 +73,8 @@ export function useMicVAD(options: Partial<ReactRealTimeVADOptions>) {
 
   const userOnFrameProcessed = useEventCallback(vadOptions.onFrameProcessed)
   vadOptions.onFrameProcessed = useEventCallback((probs, frame) => {
-    updateUserSpeaking(probs.isSpeech)
+    const isSpeaking = probs.isSpeech > reactOptions.userSpeakingThreshold
+    updateUserSpeaking(isSpeaking)
     userOnFrameProcessed(probs, frame)
   })
   const { onSpeechEnd, onSpeechStart, onSpeechRealStart, onVADMisfire } =


### PR DESCRIPTION
## Description of changes

<!--
Please describe your changes and link to related issues.
-->

This fix prevents unnecessary frequent renders when starting to listen fixing the issue described in https://github.com/ricky0123/vad/issues/166. The problem occurred because the useReducer update function was being called (to update userSpeaking) on every frame in onFrameProcessed, where updateUserSpeaking is invoked.

## Checklist

<!--
Please do all of the following that apply to your PR.
If you are submitting an update to the source code of vad-web or vad-react,
all items will likely be relevant. You are welcome to create your PR as a draft
PR without having completed all items.
-->

- [x] Verified that changes work on the test site, adding changes to the test site if necessary to try out your changes <!-- `npm run dev` to run the test site locally. Alternatively, you can open a PR and vercel will deploy a preview version of the test site that you can view -->
- [ ] Updated relevant changelogs <!-- see the `/changelogs` directory -->
- [x] Ran `npm run format`
