### PR TITLE
Update real-time-vad.ts to return the correct model

### DIFF
--- a/packages/web/src/real-time-vad.ts
+++ b/packages/web/src/real-time-vad.ts
@@ -124,7 +124,7 @@ export const getDefaultRealTimeVADOptions: (
       "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.14.0/dist/",
     stream: undefined,
     ortConfig: undefined,
-    model: DEFAULT_MODEL,
+    model: model,
     workletOptions: {},
   }
 }


### PR DESCRIPTION
## Description of changes

Currently the function `getDefaultRealTimeVADOptions` returns the legacy model even if we give `v5` as the input which doesn't seem right. This PR should fix that.
<!--
Please describe your changes and link to related issues.
-->

## Checklist

<!--
Please do all of the following that apply to your PR.
If you are submitting an update to the source code of vad-web or vad-react,
all items will likely be relevant. You are welcome to create your PR as a draft
PR without having completed all items.
-->

- [x] Verified that changes work on the test site, adding changes to the test site if necessary to try out your changes <!-- `npm run dev` to run the test site locally. Alternatively, you can open a PR and vercel will deploy a preview version of the test site that you can view -->
- [ ] Updated relevant changelogs <!-- see the `/changelogs` directory -->
- [x] Ran `npm run format`
