### PR TITLE
Add support for automatically upsampling native mic input from 8kHz to 16kHz

### DIFF
--- a/changelogs/web-changelog.md
+++ b/changelogs/web-changelog.md
@@ -1,5 +1,8 @@
 # @ricky0123/vad-web Changelog
 
+## 0.0.25
+* automatically upsample native mic input from 8kHz to 16kHz
+
 ## 0.0.24
 
 * use correct Silero model in getDefaultRealTimeVADOptions

--- a/packages/web/src/frame-processor.ts
+++ b/packages/web/src/frame-processor.ts
@@ -172,7 +172,7 @@ export class FrameProcessor implements FrameProcessorInterface {
 
     if (speaking) {
       const speechFrameCount = audioBuffer.reduce((acc, item) => {
-        return item.isSpeech ? (acc + 1) : acc
+        return item.isSpeech ? acc + 1 : acc
       }, 0)
       if (speechFrameCount >= this.options.minSpeechFrames) {
         const audio = concatArrays(audioBuffer.map((item) => item.frame))
@@ -234,7 +234,7 @@ export class FrameProcessor implements FrameProcessorInterface {
       this.audioBuffer = []
 
       const speechFrameCount = audioBuffer.reduce((acc, item) => {
-        return item.isSpeech ? (acc + 1) : acc
+        return item.isSpeech ? acc + 1 : acc
       }, 0)
 
       if (speechFrameCount >= this.options.minSpeechFrames) {

--- a/packages/web/src/resampler.ts
+++ b/packages/web/src/resampler.ts
@@ -55,7 +55,8 @@ export class Resampler {
   }
 
   private lowPassFilter(sample: number): number {
-    this.lastFilteredValue = this.lastFilteredValue + 
+    this.lastFilteredValue =
+      this.lastFilteredValue +
       this.FILTER_COEFFICIENT * (sample - this.lastFilteredValue)
     return this.lastFilteredValue
   }
@@ -64,34 +65,48 @@ export class Resampler {
     const outputFrame = new Float32Array(this.options.targetFrameSize)
     const ratio = this.options.nativeSampleRate / this.options.targetSampleRate
 
-    if (ratio < 1) { // Upsampling case
-      const inputToOutputRatio = this.options.targetSampleRate / this.options.nativeSampleRate
+    if (ratio < 1) {
+      // Upsampling case
+      const inputToOutputRatio =
+        this.options.targetSampleRate / this.options.nativeSampleRate
 
-      for (let outputIndex = 0; outputIndex < this.options.targetFrameSize; outputIndex++) {
+      for (
+        let outputIndex = 0;
+        outputIndex < this.options.targetFrameSize;
+        outputIndex++
+      ) {
         const inputPosition = outputIndex / inputToOutputRatio
         const inputIndex = Math.floor(inputPosition)
         const fraction = inputPosition - inputIndex
 
         if (inputIndex + 1 < this.inputBuffer.length) {
           const sample1 = this.lowPassFilter(this.inputBuffer[inputIndex] || 0)
-          const sample2 = this.lowPassFilter(this.inputBuffer[inputIndex + 1] || 0)
+          const sample2 = this.lowPassFilter(
+            this.inputBuffer[inputIndex + 1] || 0
+          )
           outputFrame[outputIndex] = sample1 + fraction * (sample2 - sample1)
         } else {
-          outputFrame[outputIndex] = this.lowPassFilter(this.inputBuffer[inputIndex] || 0)
+          outputFrame[outputIndex] = this.lowPassFilter(
+            this.inputBuffer[inputIndex] || 0
+          )
         }
       }
 
-      const samplesUsed = Math.ceil(this.options.targetFrameSize / inputToOutputRatio)
+      const samplesUsed = Math.ceil(
+        this.options.targetFrameSize / inputToOutputRatio
+      )
       this.inputBuffer = this.inputBuffer.slice(samplesUsed)
-    } else { // If ratio >= 1, we're downsampling
+    } else {
+      // If ratio >= 1, we're downsampling
       let outputIndex = 0
       let inputIndex = 0
-  
+
       while (outputIndex < this.options.targetFrameSize) {
         let sum = 0
         let num = 0
         while (
-          inputIndex < Math.min(
+          inputIndex <
+          Math.min(
             this.inputBuffer.length,
             ((outputIndex + 1) * this.options.nativeSampleRate) /
               this.options.targetSampleRate
@@ -107,10 +122,10 @@ export class Resampler {
         outputFrame[outputIndex] = sum / num
         outputIndex++
       }
-  
+
       this.inputBuffer = this.inputBuffer.slice(inputIndex)
     }
-  
+
     return outputFrame
   }
 }

--- a/packages/web/src/resampler.ts
+++ b/packages/web/src/resampler.ts
@@ -8,11 +8,13 @@ interface ResamplerOptions {
 
 export class Resampler {
   inputBuffer: Array<number>
+  private lastFilteredValue: number = 0
+  private readonly FILTER_COEFFICIENT = 0.2 // Hardcoded for 8kHz to 16kHz case
 
   constructor(public options: ResamplerOptions) {
     if (options.nativeSampleRate < 16000) {
-      log.error(
-        "nativeSampleRate is too low. Should have 16000 = targetSampleRate <= nativeSampleRate"
+      log.debug(
+        "nativeSampleRate is too low. Should have 16000 = targetSampleRate <= nativeSampleRate, will be upsampled"
       )
     }
     this.inputBuffer = []
@@ -52,34 +54,63 @@ export class Resampler {
     )
   }
 
+  private lowPassFilter(sample: number): number {
+    this.lastFilteredValue = this.lastFilteredValue + 
+      this.FILTER_COEFFICIENT * (sample - this.lastFilteredValue)
+    return this.lastFilteredValue
+  }
+
   private generateOutputFrame(): Float32Array {
     const outputFrame = new Float32Array(this.options.targetFrameSize)
-    let outputIndex = 0
-    let inputIndex = 0
+    const ratio = this.options.nativeSampleRate / this.options.targetSampleRate
 
-    while (outputIndex < this.options.targetFrameSize) {
-      let sum = 0
-      let num = 0
-      while (
-        inputIndex <
-        Math.min(
-          this.inputBuffer.length,
-          ((outputIndex + 1) * this.options.nativeSampleRate) /
-            this.options.targetSampleRate
-        )
-      ) {
-        const value = this.inputBuffer[inputIndex]
-        if (value !== undefined) {
-          sum += value
-          num++
+    if (ratio < 1) { // Upsampling case
+      const inputToOutputRatio = this.options.targetSampleRate / this.options.nativeSampleRate
+
+      for (let outputIndex = 0; outputIndex < this.options.targetFrameSize; outputIndex++) {
+        const inputPosition = outputIndex / inputToOutputRatio
+        const inputIndex = Math.floor(inputPosition)
+        const fraction = inputPosition - inputIndex
+
+        if (inputIndex + 1 < this.inputBuffer.length) {
+          const sample1 = this.lowPassFilter(this.inputBuffer[inputIndex] || 0)
+          const sample2 = this.lowPassFilter(this.inputBuffer[inputIndex + 1] || 0)
+          outputFrame[outputIndex] = sample1 + fraction * (sample2 - sample1)
+        } else {
+          outputFrame[outputIndex] = this.lowPassFilter(this.inputBuffer[inputIndex] || 0)
         }
-        inputIndex++
       }
-      outputFrame[outputIndex] = sum / num
-      outputIndex++
-    }
 
-    this.inputBuffer = this.inputBuffer.slice(inputIndex)
+      const samplesUsed = Math.ceil(this.options.targetFrameSize / inputToOutputRatio)
+      this.inputBuffer = this.inputBuffer.slice(samplesUsed)
+    } else { // If ratio >= 1, we're downsampling
+      let outputIndex = 0
+      let inputIndex = 0
+  
+      while (outputIndex < this.options.targetFrameSize) {
+        let sum = 0
+        let num = 0
+        while (
+          inputIndex < Math.min(
+            this.inputBuffer.length,
+            ((outputIndex + 1) * this.options.nativeSampleRate) /
+              this.options.targetSampleRate
+          )
+        ) {
+          const value = this.inputBuffer[inputIndex]
+          if (value !== undefined) {
+            sum += value
+            num++
+          }
+          inputIndex++
+        }
+        outputFrame[outputIndex] = sum / num
+        outputIndex++
+      }
+  
+      this.inputBuffer = this.inputBuffer.slice(inputIndex)
+    }
+  
     return outputFrame
   }
 }


### PR DESCRIPTION
## Description of changes

- implement linear interpolation for upsampling cases
- add low-pass filter to reduce aliasing artifacts
- modify input buffer handling to support upsampling
- ensure native mic input <16kHz can still be processed

## Why
On MacOS, the native mic sample rate drops to 8kHz on bluetooth devices unless using Airpods. This causes the library to throw `nativeSampleRate is too low. Should have 16000 = targetSampleRate <= nativeSampleRate` error. This change allows users to use the library on non-Apple bluetooth headsets. 

## Checklist
- [x] Verified that changes work on the test site, adding changes to the test site if necessary to try out your changes <!-- `npm run dev` to run the test site locally. Alternatively, you can open a PR and vercel will deploy a preview version of the test site that you can view -->
- [x] Updated relevant changelogs <!-- see the `/changelogs` directory -->
- [x] Ran `npm run format`
