### PR TITLE
Fix start on load mic permissions

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -9,14 +9,12 @@ import React, { useEffect, useState } from "react"
 export { utils } from "@ricky0123/vad-web"
 
 interface ReactOptions {
-  startOnLoad: boolean
   userSpeakingThreshold: number
 }
 
 export type ReactRealTimeVADOptions = RealTimeVADOptions & ReactOptions
 
 const defaultReactOptions: ReactOptions = {
-  startOnLoad: true,
   userSpeakingThreshold: 0.6,
 }
 
@@ -109,7 +107,7 @@ export function useMicVAD(options: Partial<ReactRealTimeVADOptions>) {
       }
       setVAD(myvad)
       setLoading(false)
-      if (reactOptions.startOnLoad) {
+      if (vadOptions.startOnLoad) {
         myvad?.start()
         setListening(true)
       }

--- a/packages/web/src/models/v5.ts
+++ b/packages/web/src/models/v5.ts
@@ -20,7 +20,6 @@ export class SileroV5 {
     modelFetcher: ModelFetcher
   ) => {
     log.debug("Loading VAD...")
-    log.debug("ort loglevel set to", ortInstance.env.logLevel)
     const modelArrayBuffer = await modelFetcher()
     const _session = await ortInstance.InferenceSession.create(modelArrayBuffer)
     // @ts-ignore

--- a/packages/web/src/real-time-vad.ts
+++ b/packages/web/src/real-time-vad.ts
@@ -66,6 +66,7 @@ export interface RealTimeVADOptions
   getStream: () => Promise<MediaStream>
   pauseStream: (stream: MediaStream) => Promise<void>
   resumeStream: (stream: MediaStream) => Promise<MediaStream>
+  startOnLoad: boolean
 }
 
 export const ort = ortInstance
@@ -127,10 +128,15 @@ export const getDefaultRealTimeVADOptions = (
     ortConfig: (ort) => {
       ort.env.logLevel = "error"
     },
+    startOnLoad: true,
   }
 }
 
 export class MicVAD {
+  public stream?: MediaStream
+  private sourceNode?: MediaStreamAudioSourceNode
+  private initialized = false
+
   static async new(options: Partial<RealTimeVADOptions> = {}) {
     const fullOptions: RealTimeVADOptions = {
       ...getDefaultRealTimeVADOptions(options.model ?? DEFAULT_MODEL),
@@ -138,41 +144,42 @@ export class MicVAD {
     }
     validateOptions(fullOptions)
 
-    const stream = await fullOptions.getStream()
-
     const audioContext = new AudioContext()
-    const sourceNode = new MediaStreamAudioSourceNode(audioContext, {
-      mediaStream: stream,
-    })
-
     const audioNodeVAD = await AudioNodeVAD.new(audioContext, fullOptions)
-    audioNodeVAD.receive(sourceNode)
 
-    return new MicVAD(
-      fullOptions,
-      audioContext,
-      stream,
-      audioNodeVAD,
-      sourceNode
-    )
+    const micVad = new MicVAD(fullOptions, audioContext, audioNodeVAD)
+
+    if (fullOptions.startOnLoad) {
+      try {
+        await micVad.start()
+      } catch (e) {
+        console.error("Error starting micVad", e)
+      }
+    }
+
+    return micVad
   }
 
   private constructor(
     public options: RealTimeVADOptions,
     private audioContext: AudioContext,
-    private stream: MediaStream,
     private audioNodeVAD: AudioNodeVAD,
-    private sourceNode: MediaStreamAudioSourceNode,
     private listening = false
   ) {}
 
   pause = () => {
-    this.options.pauseStream(this.stream)
+    if (this.stream) {
+      this.options.pauseStream(this.stream)
+    }
     this.audioNodeVAD.pause()
     this.listening = false
   }
 
   resume = async () => {
+    if (!this.stream) {
+      console.warn("Stream not initialized")
+      return
+    }
     this.stream = await this.options.resumeStream(this.stream)
     this.sourceNode = new MediaStreamAudioSourceNode(this.audioContext, {
       mediaStream: this.stream,
@@ -181,7 +188,16 @@ export class MicVAD {
   }
 
   start = async () => {
-    if (!this.stream.active) {
+    if (!this.initialized) {
+      const stream = await this.options.getStream()
+      this.sourceNode = new MediaStreamAudioSourceNode(this.audioContext, {
+        mediaStream: stream,
+      })
+      this.audioNodeVAD.receive(this.sourceNode)
+      this.initialized = true
+    }
+
+    if (!this.stream?.active) {
       await this.resume()
       this.audioNodeVAD.start()
       this.listening = true
@@ -195,8 +211,12 @@ export class MicVAD {
     if (this.listening) {
       this.pause()
     }
-    this.options.pauseStream(this.stream)
-    this.sourceNode.disconnect()
+    if (!this.stream || !this.sourceNode) {
+      console.warn("Stream not initialized")
+    } else {
+      this.options.pauseStream(this.stream)
+      this.sourceNode.disconnect()
+    }
     this.audioNodeVAD.destroy()
     this.audioContext.close()
   }


### PR DESCRIPTION
## Description of changes

Fixes mic permissions being requested on creating MicVAD even when startOnLoad is false (#145)

## Checklist

- [ ] Verified that the typechecking & formatting Github actions passes successfully <!-- Run `npm run format` to fix formatting issues -->
- [ ] Verified that changes work on the test site, adding changes to the test site if necessary to try out your changes <!-- `npm run dev` to run the test site locally. Alternatively, you can open a PR and vercel will deploy a preview version of the test site that you can view -->
