### PR TITLE
Pass in AudioContext as a VAD option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,6 @@
     "noUnusedParameters": true,
     
     // Additional helpful options
-  "skipLibCheck": true
+    "skipLibCheck": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,6 @@
     "noUnusedParameters": true,
     
     // Additional helpful options
-    "skipLibCheck": true
+  "skipLibCheck": true
   }
 }


### PR DESCRIPTION
## Description of changes

My project has an AudioContext already as we are constantly playing audio, so I want to pass it in.

## Checklist

- [x] Verified that the typechecking & formatting Github actions passes successfully 
- [ ] Verified that changes work on the test site, adding changes to the test site if necessary to try out your changes 

I ran npm run dev, but wasn't exactly clear wht to tes.
