### PR TITLE
Update lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12192,10 +12192,10 @@
     },
     "packages/react": {
       "name": "@ricky0123/vad-react",
-      "version": "0.0.34",
+      "version": "0.0.35",
       "license": "ISC",
       "dependencies": {
-        "@ricky0123/vad-web": "0.0.28",
+        "@ricky0123/vad-web": "0.0.29",
         "onnxruntime-web": "^1.17.0"
       },
       "devDependencies": {
@@ -12220,7 +12220,7 @@
     },
     "packages/web": {
       "name": "@ricky0123/vad-web",
-      "version": "0.0.28",
+      "version": "0.0.29",
       "license": "ISC",
       "dependencies": {
         "onnxruntime-web": "^1.17.0"
@@ -12743,7 +12743,7 @@
     "@ricky0123/vad-react": {
       "version": "file:packages/react",
       "requires": {
-        "@ricky0123/vad-web": "0.0.28",
+        "@ricky0123/vad-web": "0.0.29",
         "@types/react": "18.0.28",
         "onnxruntime-web": "^1.17.0"
       },


### PR DESCRIPTION
## Description of changes

The `package-lock.json` file is outdated. I just used `npm install` to keep the lockfile synced.

## Checklist

- [x] Verified that the typechecking & formatting Github actions passes successfully <!-- Run `npm run format` to fix formatting issues -->
- [x] Verified that changes work on the test site, adding changes to the test site if necessary to try out your changes <!-- `npm run dev` to run the test site locally. Alternatively, you can open a PR and vercel will deploy a preview version of the test site that you can view -->
