### PR TITLE
fix: add model cleanup to prevent memory leaks

### DIFF
--- a/packages/web/src/models/common.ts
+++ b/packages/web/src/models/common.ts
@@ -18,4 +18,5 @@ export type ModelFactory = (
 export interface Model {
   reset_state: () => void
   process: (arr: Float32Array) => Promise<SpeechProbabilities>
+  release: () => void
 }

--- a/packages/web/src/models/legacy.ts
+++ b/packages/web/src/models/legacy.ts
@@ -52,4 +52,11 @@ export class SileroLegacy {
     const notSpeech = 1 - isSpeech
     return { notSpeech, isSpeech }
   }
+
+  release = () => {
+    this._session.release()
+    this._h.dispose()
+    this._c.dispose()
+    this._sr.dispose()
+  }
 }

--- a/packages/web/src/models/v5.ts
+++ b/packages/web/src/models/v5.ts
@@ -57,4 +57,10 @@ export class SileroV5 {
     const notSpeech = 1 - isSpeech
     return { notSpeech, isSpeech }
   }
+
+  release = () => {
+    this._session.release()
+    this._state.dispose()
+    this._sr.dispose()
+  }
 }

--- a/packages/web/src/real-time-vad.ts
+++ b/packages/web/src/real-time-vad.ts
@@ -234,6 +234,7 @@ export class MicVAD {
   private constructor(
     public options: RealTimeVADOptions,
     private readonly frameProcessor: FrameProcessor,
+    private readonly model: Model,
     private readonly frameSamples: 512 | 1536,
     public listening = false,
     public errored: string | null = null,
@@ -296,7 +297,7 @@ export class MicVAD {
       msPerFrame
     )
 
-    const micVad = new MicVAD(fullOptions, frameProcessor, frameSamples)
+    const micVad = new MicVAD(fullOptions, frameProcessor, model, frameSamples)
 
     // things would be simpler if we didn't have to startOnLoad by default, but we are locked in
     if (fullOptions.startOnLoad) {
@@ -481,6 +482,7 @@ export class MicVAD {
     if (this.listening) {
       this.pause()
     }
+    this.model.release()
     if (this.ownsAudioContext) {
       this._audioContext?.close()
     }


### PR DESCRIPTION
Add release() method to dispose ONNX sessions and tensors when destroying MicVAD instances.

## Description of changes

https://github.com/ricky0123/vad/issues/245

## Checklist

<!--
Please do all of the following that apply to your PR.
If you are submitting an update to the source code of vad-web or vad-react,
all items will likely be relevant. You are welcome to create your PR as a draft
PR without having completed all items.
-->

- [ ] Verified that the typechecking & formatting Github actions passes successfully <!-- Run `npm run format` to fix formatting issues -->
- [ ] Verified that changes work on the test site, adding changes to the test site if necessary to try out your changes <!-- `npm run dev` to run the test site locally. Alternatively, you can open a PR and vercel will deploy a preview version of the test site that you can view -->
