### PR TITLE
Avoid `return await` usages

### DIFF
--- a/docs/user-guide/browser.md
+++ b/docs/user-guide/browser.md
@@ -154,7 +154,7 @@ import { MicVAD } from "@ricky0123/vad-web"
 
 const myvad = await MicVAD.new({
   getStream: async () => {
-    return await navigator.mediaDevices.getUserMedia({
+    return navigator.mediaDevices.getUserMedia({
       audio: {
         channelCount: 2, // Stereo instead of mono
         echoCancellation: false, // Disable echo cancellation

--- a/docs/user-guide/react.md
+++ b/docs/user-guide/react.md
@@ -31,7 +31,7 @@
     const MyComponent = () => {
     const vad = useMicVAD({
         getStream: async () => {
-            return await navigator.mediaDevices.getUserMedia({
+            return navigator.mediaDevices.getUserMedia({
                 audio: {
                     channelCount: 2,  // Stereo
                     echoCancellation: false,


### PR DESCRIPTION
## Description of changes

FYI https://eslint.org/docs/latest/rules/no-return-await

## Checklist

- [x] Verified that the typechecking & formatting Github actions passes successfully <!-- Run `npm run format` to fix formatting issues -->
- [x] Verified that changes work on the test site, adding changes to the test site if necessary to try out your changes <!-- `npm run dev` to run the test site locally. Alternatively, you can open a PR and vercel will deploy a preview version of the test site that you can view -->
