### PR TITLE
Add maxSpeechMs option

### DIFF
--- a/docs/user-guide/algorithm.md
+++ b/docs/user-guide/algorithm.md
@@ -18,3 +18,4 @@ All of the main APIs accept certain common configuration parameters that modify 
 * `redemptionMs: number` - number of milliseconds of speech-negative frames to wait before ending a speech segment. default: `1400`
 * `preSpeechPadMs: number` - number of milliseconds of audio to prepend to a speech segment. default: `800`
 * `minSpeechMs: number` - minimum duration in milliseconds for a speech segment. default: `400`
+* `maxSpeechMs: number` - maximum duration in milliseconds for a speech segment. If a speech segment exceeds this duration, it will be force-cut and emitted, and a new segment will start if speech is still detected. default: `Infinity`

--- a/docs/user-guide/api.md
+++ b/docs/user-guide/api.md
@@ -42,6 +42,7 @@ New instances of `MicVAD` are created by calling the async static method `MicVAD
 | `redemptionMs`            | `number`                                                                           | `1400`                                               | [see algorithm configuration](algorithm.md#configuration)                                                                                                                                                                                                                                                  |
 | `preSpeechPadMs`          | `number`                                                                           | `800`                                                | [see algorithm configuration](algorithm.md#configuration)                                                                                                                                                                                                                                                  |
 | `minSpeechMs`             | `number`                                                                           | `400`                                                | [see algorithm configuration](algorithm.md#configuration)                                                                                                                                                                                                                                                  |
+| `maxSpeechMs`             | `number`                                                                           | `Infinity`                                           | [see algorithm configuration](algorithm.md#configuration)                                                                                                                                                                                                                                                  |
 | `submitUserSpeechOnPause` | `boolean`                                                                          | `false`                                              | If true, pausing the VAD triggers `onSpeechEnd` (if speaking with sufficient frames) or `onVADMisfire`                                                                                                                                                                                                     |
 | `model`                   | `"v5" or "legacy"`                                                                 | `"legacy"`                                           | whether to use the new Silero model or not                                                                                                                                                                                                                                                                 |
 | `baseAssetPath`           | `string`                                                                           | `/`                                                  | URL or path relative to webroot where `vad.worklet.bundle.min.js`, `silero_vad_legacy.onnx`, and `silero_vad_v5.onnx` will be loaded from                                                                                                                                                                  |
@@ -96,6 +97,7 @@ New instances of `MicVAD` are created by calling the async static method `MicVAD
 
 | `preSpeechPadMs` | `number` | `30` | [see algorithm configuration](algorithm.md#configuration) |
 | `minSpeechMs` | `number` | `250` | [see algorithm configuration](algorithm.md#configuration) |
+| `maxSpeechMs` | `number` | `Infinity` | [see algorithm configuration](algorithm.md#configuration) |
 
 ### Attributes
 
@@ -150,6 +152,7 @@ The `useMicVAD` hook takes an options object with the following fields (all are 
 
 | `preSpeechPadMs` | `number` | `800` | [see algorithm configuration](algorithm.md#configuration) |
 | `minSpeechMs` | `number` | `400` | [see algorithm configuration](algorithm.md#configuration) |
+| `maxSpeechMs` | `number` | `Infinity` | [see algorithm configuration](algorithm.md#configuration) |
 
 ### Returns
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -45,6 +45,7 @@ function useOptions(
     redemptionMs: fullOptions.redemptionMs,
     preSpeechPadMs: fullOptions.preSpeechPadMs,
     minSpeechMs: fullOptions.minSpeechMs,
+    maxSpeechMs: fullOptions.maxSpeechMs,
     submitUserSpeechOnPause: fullOptions.submitUserSpeechOnPause,
     onFrameProcessed: fullOptions.onFrameProcessed,
     onVADMisfire: fullOptions.onVADMisfire,

--- a/packages/web/src/frame-processor.ts
+++ b/packages/web/src/frame-processor.ts
@@ -121,7 +121,12 @@ function calculateFrameParams(
   const preSpeechPadFrames = Math.floor(options.preSpeechPadMs / msPerFrame)
   const minSpeechFrames = Math.floor(options.minSpeechMs / msPerFrame)
   const maxSpeechFrames = Math.floor(options.maxSpeechMs / msPerFrame)
-  return { redemptionFrames, preSpeechPadFrames, minSpeechFrames, maxSpeechFrames }
+  return {
+    redemptionFrames,
+    preSpeechPadFrames,
+    minSpeechFrames,
+    maxSpeechFrames,
+  }
 }
 
 export class FrameProcessor implements FrameProcessorInterface {
@@ -145,8 +150,12 @@ export class FrameProcessor implements FrameProcessorInterface {
     public msPerFrame: number
   ) {
     this.audioBuffer = []
-    const { redemptionFrames, preSpeechPadFrames, minSpeechFrames, maxSpeechFrames } =
-      calculateFrameParams(this.options, this.msPerFrame)
+    const {
+      redemptionFrames,
+      preSpeechPadFrames,
+      minSpeechFrames,
+      maxSpeechFrames,
+    } = calculateFrameParams(this.options, this.msPerFrame)
     this.redemptionFrames = redemptionFrames
     this.preSpeechPadFrames = preSpeechPadFrames
     this.minSpeechFrames = minSpeechFrames
@@ -156,8 +165,12 @@ export class FrameProcessor implements FrameProcessorInterface {
 
   setOptions = (update: Partial<FrameProcessorOptions>) => {
     this.options = { ...this.options, ...update }
-    const { redemptionFrames, preSpeechPadFrames, minSpeechFrames, maxSpeechFrames } =
-      calculateFrameParams(this.options, this.msPerFrame)
+    const {
+      redemptionFrames,
+      preSpeechPadFrames,
+      minSpeechFrames,
+      maxSpeechFrames,
+    } = calculateFrameParams(this.options, this.msPerFrame)
     this.redemptionFrames = redemptionFrames
     this.preSpeechPadFrames = preSpeechPadFrames
     this.minSpeechFrames = minSpeechFrames

--- a/packages/web/src/frame-processor.ts
+++ b/packages/web/src/frame-processor.ts
@@ -36,6 +36,14 @@ export interface FrameProcessorOptions {
    * If true, when the user pauses the VAD, it may trigger `onSpeechEnd`.
    */
   submitUserSpeechOnPause: boolean
+
+  /**
+   * Maximum duration of speech segments in milliseconds.
+   * If a speech segment exceeds this duration, it will be force-cut and emitted,
+   * and a new segment will start if speech is still detected.
+   * Default: Infinity (no limit)
+   */
+  maxSpeechMs: number
 }
 
 export const defaultFrameProcessorOptions: FrameProcessorOptions = {
@@ -45,6 +53,7 @@ export const defaultFrameProcessorOptions: FrameProcessorOptions = {
   redemptionMs: 1400,
   minSpeechMs: 400,
   submitUserSpeechOnPause: false,
+  maxSpeechMs: Infinity,
 }
 
 export function validateOptions(options: FrameProcessorOptions) {
@@ -70,6 +79,9 @@ export function validateOptions(options: FrameProcessorOptions) {
   }
   if (options.minSpeechMs < 0) {
     log.error("minSpeechMs should be positive")
+  }
+  if (options.maxSpeechMs < 0) {
+    log.error("maxSpeechMs should be positive")
   }
 }
 
@@ -108,13 +120,15 @@ function calculateFrameParams(
   const redemptionFrames = Math.floor(options.redemptionMs / msPerFrame)
   const preSpeechPadFrames = Math.floor(options.preSpeechPadMs / msPerFrame)
   const minSpeechFrames = Math.floor(options.minSpeechMs / msPerFrame)
-  return { redemptionFrames, preSpeechPadFrames, minSpeechFrames }
+  const maxSpeechFrames = Math.floor(options.maxSpeechMs / msPerFrame)
+  return { redemptionFrames, preSpeechPadFrames, minSpeechFrames, maxSpeechFrames }
 }
 
 export class FrameProcessor implements FrameProcessorInterface {
   redemptionFrames: number
   preSpeechPadFrames: number
   minSpeechFrames: number
+  maxSpeechFrames: number
   speaking: boolean = false
   audioBuffer: { frame: Float32Array; isSpeech: boolean }[]
   redemptionCounter = 0
@@ -131,21 +145,23 @@ export class FrameProcessor implements FrameProcessorInterface {
     public msPerFrame: number
   ) {
     this.audioBuffer = []
-    const { redemptionFrames, preSpeechPadFrames, minSpeechFrames } =
+    const { redemptionFrames, preSpeechPadFrames, minSpeechFrames, maxSpeechFrames } =
       calculateFrameParams(this.options, this.msPerFrame)
     this.redemptionFrames = redemptionFrames
     this.preSpeechPadFrames = preSpeechPadFrames
     this.minSpeechFrames = minSpeechFrames
+    this.maxSpeechFrames = maxSpeechFrames
     this.reset()
   }
 
   setOptions = (update: Partial<FrameProcessorOptions>) => {
     this.options = { ...this.options, ...update }
-    const { redemptionFrames, preSpeechPadFrames, minSpeechFrames } =
+    const { redemptionFrames, preSpeechPadFrames, minSpeechFrames, maxSpeechFrames } =
       calculateFrameParams(this.options, this.msPerFrame)
     this.redemptionFrames = redemptionFrames
     this.preSpeechPadFrames = preSpeechPadFrames
     this.minSpeechFrames = minSpeechFrames
+    this.maxSpeechFrames = maxSpeechFrames
   }
 
   reset = () => {
@@ -225,6 +241,26 @@ export class FrameProcessor implements FrameProcessorInterface {
     ) {
       this.speechRealStartFired = true
       handleEvent({ msg: Message.SpeechRealStart })
+    }
+
+    if (this.speaking && this.audioBuffer.length >= this.maxSpeechFrames) {
+      const audio = concatArrays(this.audioBuffer.map((item) => item.frame))
+      handleEvent({ msg: Message.SpeechEnd, audio })
+
+      this.audioBuffer = []
+      this.speechFrameCount = 0
+      this.redemptionCounter = 0
+
+      if (isSpeech) {
+        this.audioBuffer.push({ frame, isSpeech })
+        this.speechFrameCount = 1
+        handleEvent({ msg: Message.SpeechStart })
+        this.speechRealStartFired = false
+      } else {
+        this.speaking = false
+        this.speechRealStartFired = false
+      }
+      return
     }
 
     if (

--- a/packages/web/src/non-real-time-vad.ts
+++ b/packages/web/src/non-real-time-vad.ts
@@ -58,6 +58,7 @@ export class NonRealTimeVAD {
         redemptionMs: fullOptions.redemptionMs,
         preSpeechPadMs: fullOptions.preSpeechPadMs,
         minSpeechMs: fullOptions.minSpeechMs,
+        maxSpeechMs: fullOptions.maxSpeechMs,
         submitUserSpeechOnPause: fullOptions.submitUserSpeechOnPause,
       },
       1536 / 16
@@ -105,6 +106,8 @@ export class NonRealTimeVAD {
           case Message.SpeechEnd:
             end = ((frameIndex + 1) * this.frameSamples) / 16
             yield { audio: event.audio, start, end }
+            // Reset start for potential new segment (maxSpeechMs force-cut case)
+            start = end
             break
 
           default:

--- a/packages/web/src/real-time-vad.ts
+++ b/packages/web/src/real-time-vad.ts
@@ -298,6 +298,7 @@ export class MicVAD {
         preSpeechPadMs: fullOptions.preSpeechPadMs,
         minSpeechMs: fullOptions.minSpeechMs,
         submitUserSpeechOnPause: fullOptions.submitUserSpeechOnPause,
+        maxSpeechMs: fullOptions.maxSpeechMs,
       },
       msPerFrame
     )

--- a/test-site/src/index.tsx
+++ b/test-site/src/index.tsx
@@ -29,6 +29,7 @@ interface SettableParameters {
   redemptionMs: number
   preSpeechPadMs: number
   minSpeechMs: number
+  maxSpeechMs: number
   startOnLoad: boolean
   userSpeakingThreshold: number
   processorType: "auto" | "AudioWorklet" | "ScriptProcessor"
@@ -58,6 +59,8 @@ const settableParameterDescriptions: Record<keyof SettableParameters, string> =
       "Number of milliseconds of audio to prepend to a speech segment.",
     minSpeechMs:
       "Minimum duration in milliseconds for a speech segment to be considered valid.",
+    maxSpeechMs:
+      "Maximum duration in milliseconds for a speech segment. Segments longer than this will be force-cut.",
     startOnLoad: "Whether to start VAD automatically when the component loads.",
     processorType:
       "The type of audio processor to use. 'auto' for automatic detection, 'AudioWorklet' for AudioWorklet, 'ScriptProcessor' for ScriptProcessor.",
@@ -150,6 +153,13 @@ const settableParameterValidators: {
     }
     console.error("Invalid minSpeechMs value", value)
     throw new Error("Invalid minSpeechMs value")
+  },
+  maxSpeechMs: (value: unknown) => {
+    if (typeof value == "object" && value !== null && "maxSpeechMs" in value) {
+      if (typeof value.maxSpeechMs === "number") return value.maxSpeechMs
+    }
+    console.error("Invalid maxSpeechMs value", value)
+    throw new Error("Invalid maxSpeechMs value")
   },
   startOnLoad: (value: unknown) => {
     if (typeof value == "object" && value !== null && "startOnLoad" in value) {
@@ -270,6 +280,13 @@ const settableParameterFormElement: SettableParameterFormElement = {
   minSpeechMs: (newValue, setSettableParamsFn) => (
     <NumberInput
       optionName="minSpeechMs"
+      newValue={newValue}
+      setSettableParamsFn={setSettableParamsFn}
+    />
+  ),
+  maxSpeechMs: (newValue, setSettableParamsFn) => (
+    <NumberInput
+      optionName="maxSpeechMs"
       newValue={newValue}
       setSettableParamsFn={setSettableParamsFn}
     />
@@ -452,6 +469,7 @@ const defaultSettableParams: SettableParameters = {
   redemptionMs: defaultVADOptions.redemptionMs,
   preSpeechPadMs: defaultVADOptions.preSpeechPadMs,
   minSpeechMs: defaultVADOptions.minSpeechMs,
+  maxSpeechMs: defaultVADOptions.maxSpeechMs,
   startOnLoad: defaultVADOptions.startOnLoad,
   userSpeakingThreshold: defaultVADOptions.userSpeakingThreshold,
   customStream: false,
@@ -484,6 +502,7 @@ const getSettableParamsFromHash = (): SettableParameters => {
       redemptionMs: settableParameterValidators.redemptionMs(out),
       preSpeechPadMs: settableParameterValidators.preSpeechPadMs(out),
       minSpeechMs: settableParameterValidators.minSpeechMs(out),
+      maxSpeechMs: settableParameterValidators.maxSpeechMs(out),
       startOnLoad: settableParameterValidators.startOnLoad(out),
       userSpeakingThreshold:
         settableParameterValidators.userSpeakingThreshold(out),
@@ -538,6 +557,7 @@ const settableParamsToVADParams = async (
     redemptionMs: settableParams.redemptionMs,
     preSpeechPadMs: settableParams.preSpeechPadMs,
     minSpeechMs: settableParams.minSpeechMs,
+    maxSpeechMs: settableParams.maxSpeechMs,
     submitUserSpeechOnPause: settableParams.submitUserSpeechOnPause,
 
     // From RealTimeVADCallbacks
@@ -780,6 +800,7 @@ function App() {
             {_embedForm("redemptionMs")}
             {_embedForm("preSpeechPadMs")}
             {_embedForm("minSpeechMs")}
+            {_embedForm("maxSpeechMs")}
             {_embedForm("startOnLoad")}
             {_embedForm("userSpeakingThreshold")}
             {_embedForm("customStream")}

--- a/test-site/src/index.tsx
+++ b/test-site/src/index.tsx
@@ -12,13 +12,11 @@ import NonRealTimeTest from "./non-real-time-test"
 React // prevent prettier imports plugin from removing React
 
 const domContainer = document.querySelector("#demo")
-const nonRealTimeContainer = document.querySelector("#non-real-time-test")
 
-if (!domContainer || !nonRealTimeContainer) {
-  throw new Error("domContainer or nonRealTimeContainer doesn't exist")
+if (!domContainer) {
+  throw new Error("domContainer doesn't exist")
 }
 createRoot(domContainer).render(<App />)
-createRoot(nonRealTimeContainer).render(<NonRealTimeTest />)
 
 interface SettableParameters {
   // Directly translatable VAD parameters
@@ -779,8 +777,9 @@ function App() {
     embedForm(settableParams, setSettableParams, k)
 
   return (
-    <div className="flex">
-      <div className="mr-5">
+    <div>
+      <div className="flex">
+        <div className="mr-5">
         <h3>Configuration Parameters</h3>
         <table>
           <thead>
@@ -846,6 +845,15 @@ function App() {
           />
         )}
       </div>
+      </div>
+      <NonRealTimeTest
+        positiveSpeechThreshold={settableParams.positiveSpeechThreshold}
+        negativeSpeechThreshold={settableParams.negativeSpeechThreshold}
+        redemptionMs={settableParams.redemptionMs}
+        preSpeechPadMs={settableParams.preSpeechPadMs}
+        minSpeechMs={settableParams.minSpeechMs}
+        maxSpeechMs={settableParams.maxSpeechMs}
+      />
     </div>
   )
 }

--- a/test-site/src/index.tsx
+++ b/test-site/src/index.tsx
@@ -780,71 +780,71 @@ function App() {
     <div>
       <div className="flex">
         <div className="mr-5">
-        <h3>Configuration Parameters</h3>
-        <table>
-          <thead>
-            <tr>
-              <th>Option</th>
-              <th>Current Value</th>
-              <th>New Value</th>
-            </tr>
-          </thead>
-          <tbody>
-            {_embedForm("model")}
-            {_embedForm("processorType")}
-            {_embedForm("assetPaths")}
-            {_embedForm("submitUserSpeechOnPause")}
-            {_embedForm("positiveSpeechThreshold")}
-            {_embedForm("negativeSpeechThreshold")}
-            {_embedForm("redemptionMs")}
-            {_embedForm("preSpeechPadMs")}
-            {_embedForm("minSpeechMs")}
-            {_embedForm("maxSpeechMs")}
-            {_embedForm("startOnLoad")}
-            {_embedForm("userSpeakingThreshold")}
-            {_embedForm("customStream")}
-            {_embedForm("useCustomAudioContext")}
-          </tbody>
-        </table>
+          <h3>Configuration Parameters</h3>
+          <table>
+            <thead>
+              <tr>
+                <th>Option</th>
+                <th>Current Value</th>
+                <th>New Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              {_embedForm("model")}
+              {_embedForm("processorType")}
+              {_embedForm("assetPaths")}
+              {_embedForm("submitUserSpeechOnPause")}
+              {_embedForm("positiveSpeechThreshold")}
+              {_embedForm("negativeSpeechThreshold")}
+              {_embedForm("redemptionMs")}
+              {_embedForm("preSpeechPadMs")}
+              {_embedForm("minSpeechMs")}
+              {_embedForm("maxSpeechMs")}
+              {_embedForm("startOnLoad")}
+              {_embedForm("userSpeakingThreshold")}
+              {_embedForm("customStream")}
+              {_embedForm("useCustomAudioContext")}
+            </tbody>
+          </table>
 
-        <h3>Final VAD Parameters</h3>
-        <div className="mb-4">
-          <textarea
-            value={JSON.stringify(vadParams, null, 2)}
-            readOnly
-            className="w-full h-40 p-2 border rounded font-mono text-sm bg-gray-50"
-            onClick={(e) => {
-              if (e.target instanceof HTMLTextAreaElement) {
-                e.target.select()
-              } else {
-                console.error("Unexpected target type")
-              }
-            }}
-          />
-          <p className="text-sm text-gray-600 mt-1">
-            Click to select all - these are the actual parameters passed to the
-            VAD
-          </p>
+          <h3>Final VAD Parameters</h3>
+          <div className="mb-4">
+            <textarea
+              value={JSON.stringify(vadParams, null, 2)}
+              readOnly
+              className="w-full h-40 p-2 border rounded font-mono text-sm bg-gray-50"
+              onClick={(e) => {
+                if (e.target instanceof HTMLTextAreaElement) {
+                  e.target.select()
+                } else {
+                  console.error("Unexpected target type")
+                }
+              }}
+            />
+            <p className="text-sm text-gray-600 mt-1">
+              Click to select all - these are the actual parameters passed to
+              the VAD
+            </p>
+          </div>
         </div>
-      </div>
-      <div>
-        <h3>Run</h3>
-        <button
-          className="bg-violet-100 hover:bg-violet-200 rounded-full px-4 py-2"
-          onClick={() => {
-            void handleRestart()
-          }}
-        >
-          Restart
-        </button>
-        {demo && (
-          <VADDemo
-            vadParams={vadParams}
-            stream={stream}
-            audioContext={audioContext}
-          />
-        )}
-      </div>
+        <div>
+          <h3>Run</h3>
+          <button
+            className="bg-violet-100 hover:bg-violet-200 rounded-full px-4 py-2"
+            onClick={() => {
+              void handleRestart()
+            }}
+          >
+            Restart
+          </button>
+          {demo && (
+            <VADDemo
+              vadParams={vadParams}
+              stream={stream}
+              audioContext={audioContext}
+            />
+          )}
+        </div>
       </div>
       <NonRealTimeTest
         positiveSpeechThreshold={settableParams.positiveSpeechThreshold}

--- a/test-site/src/non-real-time-test.tsx
+++ b/test-site/src/non-real-time-test.tsx
@@ -7,7 +7,23 @@ interface AudioSegment {
   end: number
 }
 
-const NonRealTimeTest: React.FC = () => {
+interface NonRealTimeTestProps {
+  positiveSpeechThreshold: number
+  negativeSpeechThreshold: number
+  redemptionMs: number
+  preSpeechPadMs: number
+  minSpeechMs: number
+  maxSpeechMs: number
+}
+
+const NonRealTimeTest: React.FC<NonRealTimeTestProps> = ({
+  positiveSpeechThreshold,
+  negativeSpeechThreshold,
+  redemptionMs,
+  preSpeechPadMs,
+  minSpeechMs,
+  maxSpeechMs,
+}) => {
   const [segments, setSegments] = useState<AudioSegment[]>([])
   const [isProcessing, setIsProcessing] = useState(false)
   const [showMs, setShowMs] = useState(true)
@@ -47,7 +63,15 @@ const NonRealTimeTest: React.FC = () => {
               // Use default CDN assets in production
             }
 
-      const myvad = await NonRealTimeVAD.new(vadConfig)
+      const myvad = await NonRealTimeVAD.new({
+        ...vadConfig,
+        positiveSpeechThreshold,
+        negativeSpeechThreshold,
+        redemptionMs,
+        preSpeechPadMs,
+        minSpeechMs,
+        maxSpeechMs,
+      })
       const audioFile = fileInputRef.current.files[0]
       const { audio, sampleRate } = await utils.audioFileToArray(audioFile)
 


### PR DESCRIPTION
## Description of changes

Adds a new maxSpeechMs parameter to control the maximum duration of speech segments. When a speech segment exceeds this duration, it is automatically force-cut and emitted, and a new segment starts if speech is still detected.

- Added `maxSpeechMs` option (default: `Infinity`) to `FrameProcessorOptions`. Implemented force-cut logic in the `process` method that emits `SpeechEnd` when `audioBuffer.length >= maxSpeechFrames` and starts a new segment if speech continues.
- [packages/web/src/frame-processor.ts](https://github.com/ricky0123/vad/blob/master/packages/web/src/frame-processor.ts): Adds `maxSpeechMs` and force-cut logic.
- [packages/web/src/real-time-vad.ts](https://github.com/ricky0123/vad/blob/master/packages/web/src/real-time-vad.ts): Passes `maxSpeechMs` to `FrameProcessor`.
- [packages/web/src/non-real-time-vad.ts](https://github.com/ricky0123/vad/blob/master/packages/web/src/non-real-time-vad.ts): Passes `maxSpeechMs` to `FrameProcessor`.
- [packages/react/src/index.ts](https://github.com/ricky0123/vad/blob/master/packages/react/src/index.ts): Passes `maxSpeechMs` through to the underlying VAD.
- [test-site/src/index.tsx](https://github.com/ricky0123/vad/blob/master/test-site/src/index.tsx): Adds `maxSpeechMs` to the configurable parameters UI and refactors shared VAD parameters.
- [test-site/src/non-real-time-test.tsx](https://github.com/ricky0123/vad/blob/master/test-site/src/non-real-time-test.tsx): Updated to accept all VAD parameters as props from the parent component.
- [docs/user-guide/api.md](https://github.com/ricky0123/vad/blob/master/docs/user-guide/api.md): Documents `maxSpeechMs` for `MicVAD`, `NonRealTimeVAD`, and `useMicVAD`.


- Related discussion: [ricky0123/vad#79](https://github.com/ricky0123/vad/issues/79)
- Reference implementation: [Silero VAD force-cut logic](https://github.com/snakers4/silero-vad/blob/94504ece54c8caeebb808410b08ae55ee82dba82/utils_vad.py#L197)


## Checklist
- [x] Verified that the typechecking & formatting Github actions passes successfully 
- [x] Verified that changes work on the test site, adding changes to the test site if necessary to try out your changes
