### PR TITLE
Give Silero v5 its context window

### DIFF
--- a/packages/web/src/models/v5.ts
+++ b/packages/web/src/models/v5.ts
@@ -2,12 +2,19 @@ import * as ort from "onnxruntime-web/wasm"
 import { log } from "../logging"
 import { ModelFactory, ModelFetcher, SpeechProbabilities } from "./common"
 
+// Silero v5 scores a frame against the tail of the frame before it, so an onset
+// straddling a frame boundary is still seen whole. 64 samples at 16 kHz, matching
+// `OnnxWrapper.__call__` in silero-vad's utils_vad.py.
+const CONTEXT_SAMPLES = 64
+
 function getNewState(ortInstance: typeof ort) {
   const zeroes = Array(2 * 128).fill(0)
   return new ortInstance.Tensor("float32", zeroes, [2, 1, 128])
 }
 
 export class SileroV5 {
+  private _context = new Float32Array(CONTEXT_SAMPLES)
+
   constructor(
     private _session: ort.InferenceSession,
     private _state: ort.Tensor,
@@ -31,12 +38,18 @@ export class SileroV5 {
 
   reset_state = () => {
     this._state = getNewState(this.ortInstance)
+    this._context = new Float32Array(CONTEXT_SAMPLES)
   }
 
   process = async (audioFrame: Float32Array): Promise<SpeechProbabilities> => {
-    const t = new this.ortInstance.Tensor("float32", audioFrame, [
+    const withContext = new Float32Array(CONTEXT_SAMPLES + audioFrame.length)
+    withContext.set(this._context, 0)
+    withContext.set(audioFrame, CONTEXT_SAMPLES)
+    this._context = audioFrame.slice(-CONTEXT_SAMPLES)
+
+    const t = new this.ortInstance.Tensor("float32", withContext, [
       1,
-      audioFrame.length,
+      withContext.length,
     ])
     const inputs = {
       input: t,


### PR DESCRIPTION
## Description of changes

Gives Silero v5 the context window it expects. Fixes #262.

v5 scores each 512-sample frame against the last 64 samples of the frame before it, so an onset that straddles a frame boundary is still seen whole. `SileroV5.process` passed the bare frame, so the model saw every frame as the first frame of an utterance. Silero's own `OnnxWrapper.__call__` does the concatenation:

```python
context_size = 64 if sr == 16000 else 32
x = torch.cat([self._context, x], dim=1)
...
self._context = x[..., -context_size:]
```

This mirrors it. The model keeps the previous frame's tail, prepends it, and `reset_state` clears it alongside the LSTM state. `SileroV5` is fixed at 16 kHz, so the context is always 64 samples.

`legacy` is untouched, so the default model path does not change.

### Effect

On `test-site/test.wav` the aggregate barely moves, 39 to 40 frames over 0.5. That is why this went unnoticed. It lands on individual onsets:

```
frame   before   after    delta
   65   0.0131   0.7408   +0.7277
   77   0.7368   0.9491   +0.2123
  105   0.4804   0.1175   -0.3629
```

On quiet or distant speech it is much larger. Over twelve seconds of a quiet speaker, mean probability goes from 0.163 to 0.405, and frames over 0.5 from 50 to 154.

Over about two hours of speech, the gap between the highest score on room tone and the lowest on a speech segment goes from 0.063 to 0.738. The range of thresholds that keeps all speech while rejecting all room tone widens from a single value, 0.4, to 0.2 through 0.8.

### Compatibility

No API change. Existing `positiveSpeechThreshold` values keep working, though expect more speech to be detected at any given threshold. Anyone who tuned below Silero's 0.5 / 0.35 default to stop v5 missing speech can move back up.

## Checklist

- [x] Verified that the typechecking & formatting Github actions passes successfully
- [x] Verified that changes work on the test site

Run against this repo on a clean `npm ci`:

```
npm run format-check   All matched files use Prettier code style!
npm run lint           exit 0
npm run build          exit 0
npm run typecheck      exit 0
npm run test           2 passed, 0 failed
```

`typecheck` needs `build` first, or `packages/react` cannot resolve `@ricky0123/vad-web`. That is true of unpatched `master` too, with the same five errors, so it is not from this change.

End to end through `MicVAD` with `model: "v5"`, driving Chromium's fake microphone from `test-site/test.wav`, at 0.5 / 0.35:

```
          frames   mean     over 0.5   segments
before       219   0.1860         43   [2.69s]
after        219   0.1686         40   [2.56s]
```

One speech segment either way. On clean audio this is close to a no-op, which is the point of the issue's "why nobody has noticed" section. The behaviour does change, and on quiet speech it changes a lot.
